### PR TITLE
Fix layout in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       </ul>
     </nav>
     <div class="row">
-      <div class="small-12 columns banner hide-for-small text-center">
+      <div class="small-12 banner hide-for-small text-center">
         <h1>We <3 feedback!</h1>
         <p>We want to make your experience as great as possible and your
           feedback is an immensely important part of that process. Please answer


### PR DESCRIPTION
Not sure what I did, but this fixes the layout in Firefox. If there's a more proper fix, you should do that instead.
Before:
<img width="1280" alt="screen shot 2015-09-15 at 4 12 58 pm" src="https://cloud.githubusercontent.com/assets/756128/9892936/6b7c4c0c-5bc8-11e5-8c6d-4ba963555d77.png">
After:
<img width="1280" alt="screen shot 2015-09-15 at 4 38 22 pm" src="https://cloud.githubusercontent.com/assets/756128/9892940/70cad584-5bc8-11e5-8bac-1697610d0274.png">
