### PR TITLE
Fix Entypo inclusion

### DIFF
--- a/app/assets/stylesheets/fonts.css.less
+++ b/app/assets/stylesheets/fonts.css.less
@@ -1,10 +1,10 @@
 @font-face {
   font-family: "toolkit-entypo";
-  src: url('toolkit-entypo.eot');
-  src: url('toolkit-entypo.eot?#iefix') format('eot'),
-    url('toolkit-entypo.woff2') format('woff2'),
-    url('toolkit-entypo.woff') format('woff'),
-    url('toolkit-entypo.ttf') format('truetype');
+  src: font-url('toolkit-entypo.eot');
+  src: font-url('toolkit-entypo.eot?#iefix') format('eot'),
+    font-url('toolkit-entypo.woff2') format('woff2'),
+    font-url('toolkit-entypo.woff') format('woff'),
+    font-url('toolkit-entypo.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,7 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.precompile << /\.(?:svg|eot|woff|woff2|ttf)\z/
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
When implementing the icon font that comes with our Bootstrap theme I had forgotten to set it up with the asset pipeline.

This PR fixes that and has been tested when running Rails production mode. Ready for merge.
