### PR TITLE
Sort meetings and feedback by creation date

### DIFF
--- a/app/models/feedback_response.rb
+++ b/app/models/feedback_response.rb
@@ -1,4 +1,6 @@
 class FeedbackResponse < ActiveRecord::Base
+  default_scope { order('created_at DESC') }
+
   belongs_to :club_member
   belongs_to :meeting
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,4 +1,6 @@
 class Meeting < ActiveRecord::Base
+  default_scope { order('created_at DESC') }
+
   belongs_to :club
   has_many :feedback_responses, dependent: :destroy
 


### PR DESCRIPTION
This PR changes the default sort order of meetings and feedback responses to sort by their creation date, descending. This fixes any bugs that arise by a model having a higher id, but a lower creation date than a previous model.

@MaxWofford can you review/merge this when you have a chance?
