### PR TITLE
Make club members not rememberable

### DIFF
--- a/app/models/club_member.rb
+++ b/app/models/club_member.rb
@@ -1,7 +1,7 @@
 class ClubMember < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :registerable, :rememberable, :trackable, :omniauthable
+  devise :registerable, :trackable, :omniauthable
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |club_member|
       club_member.provider = auth.provider


### PR DESCRIPTION
Right now, in production, if you sign out as a club leader, the following error is thrown. This PR should fix that.

```
NoMethodError (undefined method `remember_created_at=' for #<ClubMember:0x007f15204a5f38>):
  activemodel (4.2.4) lib/active_model/attribute_methods.rb:433:in `method_missing'
  devise (3.5.2) lib/devise/models/rememberable.rb:61:in `forget_me!'
  devise (3.5.2) lib/devise/controllers/rememberable.rb:23:in `forget_me'
  devise (3.5.2) lib/devise/hooks/forgetable.rb:7:in `block in <top (required)>'
  warden (1.2.3) lib/warden/hooks.rb:14:in `call'
  warden (1.2.3) lib/warden/hooks.rb:14:in `block in _run_callbacks'
  warden (1.2.3) lib/warden/hooks.rb:9:in `each'
  warden (1.2.3) lib/warden/hooks.rb:9:in `_run_callbacks'
  warden (1.2.3) lib/warden/manager.rb:53:in `_run_callbacks'
  warden (1.2.3) lib/warden/proxy.rb:262:in `block in logout'
  warden (1.2.3) lib/warden/proxy.rb:260:in `each'
  warden (1.2.3) lib/warden/proxy.rb:260:in `logout'
  devise (3.5.2) lib/devise/controllers/sign_in_out.rb:75:in `sign_out_all_scopes'
  devise (3.5.2) lib/devise/controllers/sign_in_out.rb:57:in `sign_out'
  devise (3.5.2) app/controllers/devise/sessions_controller.rb:26:in `destroy'
  actionpack (4.2.4) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
  actionpack (4.2.4) lib/abstract_controller/base.rb:198:in `process_action'
  actionpack (4.2.4) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (4.2.4) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
  activesupport (4.2.4) lib/active_support/callbacks.rb:117:in `call'
  activesupport (4.2.4) lib/active_support/callbacks.rb:117:in `call'
  activesupport (4.2.4) lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
  activesupport (4.2.4) lib/active_support/callbacks.rb:505:in `call'
  activesupport (4.2.4) lib/active_support/callbacks.rb:505:in `call'
  activesupport (4.2.4) lib/active_support/callbacks.rb:92:in `__run_callbacks__'
  activesupport (4.2.4) lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
  activesupport (4.2.4) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.4) lib/abstract_controller/callbacks.rb:19:in `process_action'
  actionpack (4.2.4) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (4.2.4) lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
  activesupport (4.2.4) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.4) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.4) lib/active_support/notifications.rb:164:in `instrument'
  actionpack (4.2.4) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
  actionpack (4.2.4) lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
  activerecord (4.2.4) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (4.2.4) lib/abstract_controller/base.rb:137:in `process'
  actionview (4.2.4) lib/action_view/rendering.rb:30:in `process'
  actionpack (4.2.4) lib/action_controller/metal.rb:196:in `dispatch'
  actionpack (4.2.4) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
  actionpack (4.2.4) lib/action_controller/metal.rb:237:in `block in action'
  actionpack (4.2.4) lib/action_dispatch/routing/route_set.rb:76:in `call'
  actionpack (4.2.4) lib/action_dispatch/routing/route_set.rb:76:in `dispatch'
  actionpack (4.2.4) lib/action_dispatch/routing/route_set.rb:45:in `serve'
  actionpack (4.2.4) lib/action_dispatch/routing/mapper.rb:49:in `serve'
  actionpack (4.2.4) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.4) lib/action_dispatch/journey/router.rb:30:in `each'
  actionpack (4.2.4) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.4) lib/action_dispatch/routing/route_set.rb:821:in `call'
  omniauth (1.2.2) lib/omniauth/strategy.rb:186:in `call!'
  omniauth (1.2.2) lib/omniauth/strategy.rb:164:in `call'
  rack-ssl-enforcer (0.2.9) lib/rack/ssl-enforcer.rb:52:in `call'
  warden (1.2.3) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.3) lib/warden/manager.rb:34:in `catch'
  warden (1.2.3) lib/warden/manager.rb:34:in `call'
  rack (1.6.4) lib/rack/etag.rb:24:in `call'
  rack (1.6.4) lib/rack/conditionalget.rb:38:in `call'
  rack (1.6.4) lib/rack/head.rb:13:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/flash.rb:260:in `call'
  rack (1.6.4) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.6.4) lib/rack/session/abstract/id.rb:220:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  activerecord (4.2.4) lib/active_record/query_cache.rb:36:in `call'
  activerecord (4.2.4) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.2.4) lib/active_support/callbacks.rb:88:in `__run_callbacks__'
  activesupport (4.2.4) lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
  activesupport (4.2.4) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.4) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.2.4) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.4) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.2.4) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.2.4) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.2.4) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.2.4) lib/rails/rack/logger.rb:20:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  rack (1.6.4) lib/rack/methodoverride.rb:22:in `call'
  rack (1.6.4) lib/rack/runtime.rb:18:in `call'
  activesupport (4.2.4) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  actionpack (4.2.4) lib/action_dispatch/middleware/static.rb:116:in `call'
  rack (1.6.4) lib/rack/sendfile.rb:113:in `call'
  railties (4.2.4) lib/rails/engine.rb:518:in `call'
  railties (4.2.4) lib/rails/application.rb:165:in `call'
  puma (2.14.0) lib/puma/configuration.rb:78:in `call'
  puma (2.14.0) lib/puma/server.rb:541:in `handle_request'
  puma (2.14.0) lib/puma/server.rb:388:in `process_client'
  puma (2.14.0) lib/puma/server.rb:270:in `block in run'
  puma (2.14.0) lib/puma/thread_pool.rb:106:in `call'
  puma (2.14.0) lib/puma/thread_pool.rb:106:in `block in spawn_thread'
```
