### PR TITLE
Fix charts labels

### DIFF
--- a/app/helpers/clubs_helper.rb
+++ b/app/helpers/clubs_helper.rb
@@ -18,9 +18,7 @@ module ClubsHelper
   end
 
   def club_meetings_chart_labels(club)
-    [
-      data: club.meetings.map { |m| m.id }
-    ]
+    club.meetings.map { |m| m.id }
   end
 
   def club_meetings_attendees_chart_data(club)


### PR DESCRIPTION
Right now we're passing Chart.js incorrectly formatted chart labels, breaking the chart. This PR fixes the chart labels.

Here's what it looks like without this change:

![before](https://cloud.githubusercontent.com/assets/992248/10232776/727a12ae-683f-11e5-9626-70063323b5fe.png)

Here's what it looks like after this change:

![after](https://cloud.githubusercontent.com/assets/992248/10232783/7e148d7e-683f-11e5-86d2-9d34d5663734.png)

@MaxWofford can you review and merge this when you have an opportunity?
