### PR TITLE
Revert "Install yaml_db for database agnostic exports"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'rinku', require: 'rails_rinku'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
-  gem 'yaml_db'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,9 +202,6 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    yaml_db (0.3.0)
-      rails (>= 3.0, < 4.3)
-      rake (>= 0.8.7)
 
 PLATFORMS
   ruby
@@ -233,7 +230,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-  yaml_db
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Reverts hackedu/packrat#59. For some reason I wasn't able to import the data that this gem exported, so I'm going to nuke it from the Gemfile entirely.
