### PR TITLE
Tame Rails's logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'chart-js-rails'
 gem 'bootstrap-social-rails'
 gem 'rack-ssl-enforcer'
 gem 'rinku', require: 'rails_rinku'
+gem 'lograge'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -34,6 +35,7 @@ group :development do
 end
 
 group :production do
+  gem 'rails_12factor'
   gem 'puma'
   gem 'pg'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,10 @@ GEM
       sprockets (> 2, < 4)
       tilt
     libv8 (3.16.14.11)
+    lograge (0.3.4)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -148,6 +152,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (4.2.4)
       actionpack (= 4.2.4)
       activesupport (= 4.2.4)
@@ -203,12 +212,14 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   less-rails (~> 2.7)
+  lograge
   omniauth
   omniauth-github
   pg
   puma
   rack-ssl-enforcer
   rails (= 4.2.4)
+  rails_12factor
   rinku
   sdoc (~> 0.4.0)
   spring

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+end


### PR DESCRIPTION
This change installs lograge and rails_12factor. lograge shortens
Rails's logs and rails_12factor, among other things, sends logs to
stdout so they can be viewed when running in a 12factor environment in
production.
