### PR TITLE
Shrink the README logo slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-[<img src="https://i.imgur.com/rCaTfnq.png" alt="Packrat Icon" width="275" align="right">](https://soundcloud.com/friendjonathanleung/mother-duckling-pack-rats)
+[<img src="https://i.imgur.com/rCaTfnq.png" alt="Packrat Icon" width="225" align="right">](https://soundcloud.com/friendjonathanleung/mother-duckling-pack-rats)
 
 [Register a GitHub application](https://github.com/settings/applications/new)
 with the following fields:


### PR DESCRIPTION
So it turns out that the width of the rendered README when viewing the entire repository is smaller than when you click on a specific file, creating this monstrosity:

![1](https://cloud.githubusercontent.com/assets/992248/10648125/8e337280-77f1-11e5-93a0-08da158cbdbb.png)

This PR takes your pack, puts it into a rat, and then shrinks the packrat a tiny bit. Here's what the README will look like after this PR is merged:

![2](https://cloud.githubusercontent.com/assets/992248/10648138/a252c2d4-77f1-11e5-8127-26fe33c64925.png)
