### PR TITLE
Collect phone numbers in feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'analytics-ruby', require: 'segment'
 
 group :development, :test do
   gem 'faker'
+  gem 'active_record_query_trace'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_record_query_trace (1.5)
     activejob (4.2.4)
       activesupport (= 4.2.4)
       globalid (>= 0.3.0)
@@ -206,6 +207,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_record_query_trace
   analytics-ruby
   bootstrap-social-rails
   byebug

--- a/app/controllers/feedback_responses_controller.rb
+++ b/app/controllers/feedback_responses_controller.rb
@@ -7,11 +7,16 @@ class FeedbackResponsesController < ApplicationController
   end
 
   def create
-    # If this is the first submission by the club member, record their club and
-    # full name...
+    # If this is the first submission by the club member, record their club,
+    # phone number, and full name
     if current_member.user.name.blank?
       @name = member_params[:name]
-      current_member.update(user_attributes: { name: @name })
+      current_member.user.update(name: @name)
+    end
+    # ... and phone number
+    if current_member.user.phone.blank?
+      phone = member_params[:phone]
+      current_member.user.update(phone: phone)
     end
     # ... and their club
     if current_member.club.blank?
@@ -47,7 +52,7 @@ class FeedbackResponsesController < ApplicationController
     # If the form included parameters for the club member (like their name or
     # club), then it'll be present here.
     def member_params
-      params.permit(:name, :club_id)
+      params.permit(:name, :club_id, :phone)
     end
 
     # Never trust parameters from the scary internet, only allow the white list

--- a/app/views/feedback_responses/_form_modal.html.haml
+++ b/app/views/feedback_responses/_form_modal.html.haml
@@ -18,6 +18,11 @@
               %label Full name
               = text_field_tag :name, nil, class: 'form-control',
                 placeholder: 'Zaphod Beeblebrox', required: true
+          - if current_member.user.nil? || current_member.user.phone.blank?
+            .form-group
+              %label Phone number
+              = text_field_tag :phone, nil, class: 'form-control',
+                placeholder: '444-444-4444', required: true
           - if current_member.club.blank?
             .form-group
               %label Club

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Uncomment to log the source of all ActiveRecord queries
+  # ActiveRecordQueryTrace.enabled = true
+
   # Allow the web console when running with Docker Compose
   config.web_console.whitelisted_ips = '172.17.0.0/16'
 end


### PR DESCRIPTION
This change also changes the way we collect/update missing names. Instead of using `current_member.update(user_attributes: { ... })` we now use `current_member.user.update(...)` because, as it turns out, the former has a tendency to _delete_ the current_member.user model, which in turn deletes the current_member model (because of its destroy dependency). This was _very_ bad and is now fixed.

This change also adds active_record_query_trace the development group in the Gemfile. I used it to debug the deletion of current_member.user and I think it'd be helpful to have the gem at our disposal in the future, especially when we want to start thinking about performance optimization.

Closes #77.
