### PR TITLE
Expose port 3000 on 80 and 443 in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 web:
   build: .
   ports:
-    - "3000:3000"
-    - 80
-    - 443
+    - 3000:3000
+    - 80:3000
+    - 443:3000
   volumes:
     - .:/usr/src/app
   command: bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
This is needed for Convox to properly set up SSL.
